### PR TITLE
hotfix: #27 목록 조회 기능 정상화

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.ir.backend.js.compile
+
 plugins {
     kotlin("jvm") version "2.0.21"
     kotlin("plugin.jpa") version "2.0.21"
@@ -74,6 +76,8 @@ dependencies {
 
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
+
+    compileOnly("com.fasterxml.jackson.module:jackson-module-kotlin:2.9.+")
 }
 
 tasks.named<Test>("test") {

--- a/src/main/java/org/team1/nbe1_3_team01/domain/group/service/response/BelongingResponse.kt
+++ b/src/main/java/org/team1/nbe1_3_team01/domain/group/service/response/BelongingResponse.kt
@@ -3,9 +3,9 @@ package org.team1.nbe1_3_team01.domain.group.service.response
 import org.team1.nbe1_3_team01.domain.group.entity.Belonging
 
 data class BelongingResponse (
-    private val id: Long,
-    private val userId: Long,
-    private val teamId: Long
+    val id: Long,
+    val userId: Long,
+    val teamId: Long
 ) {
     companion object {
         fun from(belonging: Belonging): BelongingResponse {

--- a/src/main/java/org/team1/nbe1_3_team01/domain/group/service/response/TeamResponse.kt
+++ b/src/main/java/org/team1/nbe1_3_team01/domain/group/service/response/TeamResponse.kt
@@ -4,15 +4,14 @@ import org.team1.nbe1_3_team01.domain.group.entity.Team
 
 
 data class TeamResponse (
-    private val id: Long,
-    private val courseName: String,
-    private val teamType: String,
-    private val name: String,
-    private val creationWaiting: Boolean,
-    private val deletionWaiting: Boolean
+    val id: Long,
+    val courseName: String,
+    val teamType: String,
+    val name: String,
+    val creationWaiting: Boolean,
+    val deletionWaiting: Boolean,
+    val belongings: MutableList<BelongingResponse> = mutableListOf()
 ) {
-    private val belongings: MutableList<BelongingResponse> = ArrayList()
-
     companion object {
         fun from(team: Team): TeamResponse {
             val teamResponse: TeamResponse = TeamResponse(


### PR DESCRIPTION
## 개요
<!---- 자신이 완료한 이슈를 닫아주세요 -->
- closed #27 
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
dto 프로퍼티들에서 private을 빼고, TeamResponse의 주생성자에 belongings가 들어가도록 했습니다.
<img width="540" alt="스크린샷 2024-11-04 오후 12 27 04" src="https://github.com/user-attachments/assets/310759b4-e25a-4739-a123-bb88fcd104d0">
<img width="533" alt="스크린샷 2024-11-04 오후 12 27 17" src="https://github.com/user-attachments/assets/6b12434b-71d3-45ab-a0fc-2d48fcf69e69">
위 사진과 같은 응답을 반환합니다.
<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

📣 **To Reviewers**
---
<!-- 전달사항 -->
